### PR TITLE
URL Cleanup

### DIFF
--- a/src/Services/Basket/Basket.API/Auth/Client/oidc-token-manager.js
+++ b/src/Services/Basket/Basket.API/Auth/Client/oidc-token-manager.js
@@ -7773,7 +7773,7 @@ _promiseFactory = new DefaultPromiseFactory();
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -8264,7 +8264,7 @@ OidcClient.prototype.processResponseAsync = function (queryString) {
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*   http://www.apache.org/licenses/LICENSE-2.0
+*   https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Services/Identity/Identity.API/wwwroot/lib/jquery-validation/dist/additional-methods.js
+++ b/src/Services/Identity/Identity.API/wwwroot/lib/jquery-validation/dist/additional-methods.js
@@ -247,7 +247,7 @@ $.validator.addMethod("cpfBR", function(value) {
 }, "Please specify a valid CPF number");
 
 /* NOTICE: Modified version of Castle.Components.Validator.CreditCardValidator
- * Redistributed under the the Apache License 2.0 at http://www.apache.org/licenses/LICENSE-2.0
+ * Redistributed under the the Apache License 2.0 at https://www.apache.org/licenses/LICENSE-2.0
  * Valid Types: mastercard, visa, amex, dinersclub, enroute, discover, jcb, unknown, all (overrides all other settings)
  */
 $.validator.addMethod("creditcardtypes", function(value, element, param) {

--- a/src/Web/WebMonolithic/eShopWeb/wwwroot/lib/jquery-validation/dist/additional-methods.js
+++ b/src/Web/WebMonolithic/eShopWeb/wwwroot/lib/jquery-validation/dist/additional-methods.js
@@ -247,7 +247,7 @@ $.validator.addMethod("cpfBR", function(value) {
 }, "Please specify a valid CPF number");
 
 /* NOTICE: Modified version of Castle.Components.Validator.CreditCardValidator
- * Redistributed under the the Apache License 2.0 at http://www.apache.org/licenses/LICENSE-2.0
+ * Redistributed under the the Apache License 2.0 at https://www.apache.org/licenses/LICENSE-2.0
  * Valid Types: mastercard, visa, amex, dinersclub, enroute, discover, jcb, unknown, all (overrides all other settings)
  */
 $.validator.addMethod("creditcardtypes", function(value, element, param) {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 4 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).